### PR TITLE
Adding support for supplementing ENV with secrets values

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,5 @@ group :test do
   gem "aruba", "~> 0.6.2"
   gem "codeclimate-test-reporter", require: false
   gem "rspec", "~> 3.1"
-  gem "sqlite3", "~> 1.3"
+  gem "sqlite3", "~> 1.3.0"
 end

--- a/figaro.gemspec
+++ b/figaro.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name    = "figaro"
-  gem.version = "1.1.1"
+  gem.version = "1.2.0"
 
   gem.author      = "Steve Richert"
   gem.email       = "steve.richert@gmail.com"

--- a/figaro.gemspec
+++ b/figaro.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name    = "figaro"
-  gem.version = "1.2.0"
+  gem.version = "1.2.1"
 
   gem.author      = "Steve Richert"
   gem.email       = "steve.richert@gmail.com"

--- a/lib/figaro/application.rb
+++ b/lib/figaro/application.rb
@@ -85,7 +85,7 @@ module Figaro
     end
 
     def key_skipped!(key)
-      warn "WARNING: Skipping key #{key.inspect}. Already set in ENV."
+      warn "WARNING: [SKIP] Skipping key #{key.inspect}. Already set in ENV."
     end
   end
 end

--- a/lib/figaro/rails/application.rb
+++ b/lib/figaro/rails/application.rb
@@ -1,10 +1,20 @@
 module Figaro
   module Rails
     class Application < Figaro::Application
+      def skip_secret?(key)
+        ::ENV.key?(key.to_s)
+      end
 
       def load_secrets
         ::Rails.application.secrets.each do |key,value|
-          skip?(key) ? key_skipped!(key) : set(key, value)
+          # Proactive convert to string to avoid warning about string conversion
+          key = key.to_s
+          if skip_secret?(key)
+            key_skipped!(key)
+          else
+            warn "WARNING: [SET] Setting key #{key.inspect} from Rails.application.secrets.#{key} ..."
+            set(key, value)
+          end
         end
       end
 

--- a/lib/figaro/rails/application.rb
+++ b/lib/figaro/rails/application.rb
@@ -1,6 +1,13 @@
 module Figaro
   module Rails
     class Application < Figaro::Application
+
+      def load_secrets
+        ::Rails.application.secrets.each do |key,value|
+          skip?(key) ? key_skipped!(key) : set(key, value)
+        end
+      end
+
       private
 
       def default_path

--- a/lib/figaro/rails/railtie.rb
+++ b/lib/figaro/rails/railtie.rb
@@ -4,6 +4,10 @@ module Figaro
       config.before_configuration do
         Figaro.load
       end
+
+      config.before_initialize do
+        Figaro.application.load_secrets
+      end
     end
   end
 end


### PR DESCRIPTION
No CI setup yet, but test pass:

```$ bundle exec rspec spec/figaro/rails/application_spec.rb

Randomized with seed 36531
.....WARNING: Use strings for Figaro configuration. :string_key was converted to "string_key".
WARNING: Use strings for Figaro configuration. :hash_key was converted to "hash_key".
WARNING: Use strings for Figaro configuration. {"key"=>"value"} was converted to "{\"key\"=>\"value\"}".
WARNING: Use strings for Figaro configuration. :boolean_key was converted to "boolean_key".
WARNING: Use strings for Figaro configuration. true was converted to "true".
WARNING: Use strings for Figaro configuration. :foo was converted to "foo".
.

Finished in 0.01695 seconds (files took 0.42433 seconds to load)
6 examples, 0 failures

Randomized with seed 36531
```